### PR TITLE
Docs: Correct upstream URL in contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We appreciate your interest in contributing to **MeTube**. Here's how you can ge
 
 4. **Add an upstream link to the main branch in your cloned repo:**
 ```
-    git remote add upstream https://github.com/<your_github_username>/MeTube.git
+    git remote add upstream https://github.com/Open-Source-Chandigarh/MeTube.git
 ```
 5. **Keep your cloned repo up to date by pulling from upstream (this will also avoid any merge conflicts while committing new changes):**
 ```


### PR DESCRIPTION
Closes #35 

## Description

This pull request corrects an error in the contributing guide within the `README.md` file.

The previous command for adding the `upstream` remote was pointing to the user's own fork (`<your_github_username>`) instead of the main project repository. This would prevent contributors from being able to properly pull the latest changes from the original project.

This PR updates the URL to point to the correct `Open-Source-Chandigarh/MeTube` repository, ensuring a smoother setup process for all future contributors.