### PR TITLE
feat: Add Picture-in-Picture (PiP) mini player with full playback pre…

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,11 @@
             <div class="video-container">
                 <div id="videoWrapper">
                     <iframe id="videoPlayer" src="" frameborder="0" allowfullscreen></iframe>
+                    <div class="video-controls-overlay">
+                        <button id="pipButton" class="pip-button" onclick="togglePictureInPicture()" title="Picture-in-Picture" aria-label="Enable Picture-in-Picture mode">
+                            <span class="material-symbols-outlined">picture_in_picture_alt</span>
+                        </button>
+                    </div>
                 </div>
                 <h2 id="videoTitle" class="video-title"></h2>
                 
@@ -240,6 +245,24 @@
                 <div class="voice-status-text" id="voiceStatusText">Listening...</div>
                 <div class="voice-transcript" id="voiceTranscript">Say something...</div>
                 <button class="voice-close-btn" onclick="stopVoiceSearch()">Cancel</button>
+            </div>
+        </div>
+
+        <!-- Mini Player (Picture-in-Picture) -->
+        <div id="miniPlayer" class="mini-player" style="display: none;">
+            <div class="mini-player-header" id="miniPlayerHeader">
+                <span class="mini-player-title" id="miniPlayerTitle">Now Playing</span>
+                <div class="mini-player-controls">
+                    <button class="mini-control-btn" onclick="maximizeMiniPlayer()" title="Maximize" aria-label="Maximize video">
+                        <span class="material-symbols-outlined">open_in_full</span>
+                    </button>
+                    <button class="mini-control-btn" onclick="closeMiniPlayer()" title="Close" aria-label="Close mini player">
+                        <span class="material-symbols-outlined">close</span>
+                    </button>
+                </div>
+            </div>
+            <div class="mini-player-video">
+                <!-- iframe will be moved here dynamically -->
             </div>
         </div>
 

--- a/style.css
+++ b/style.css
@@ -2505,3 +2505,218 @@ a:focus-visible {
   }
 }
 
+/* ===== PICTURE-IN-PICTURE (MINI PLAYER) ===== */
+.video-controls-overlay {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 10;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+#videoWrapper:hover .video-controls-overlay {
+  opacity: 1;
+}
+
+.pip-button {
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(10px);
+  border: none;
+  border-radius: 8px;
+  color: white;
+  padding: 8px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-fast);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.pip-button:hover {
+  background: rgba(255, 71, 87, 0.9);
+  transform: scale(1.1);
+}
+
+.pip-button .material-symbols-outlined {
+  font-size: 24px;
+}
+
+/* Mini Player Floating Window */
+.mini-player {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 400px;
+  background: var(--bg-secondary);
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
+  z-index: 9999;
+  transition: all var(--transition-normal);
+  animation: slideInUp 0.3s ease-out;
+  border: 2px solid var(--border-color);
+  cursor: move;
+}
+
+.mini-player.dragging {
+  cursor: grabbing;
+  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.4);
+  transform: scale(1.02);
+}
+
+.mini-player-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background: var(--bg-primary);
+  border-bottom: 1px solid var(--border-color);
+  cursor: move;
+  user-select: none;
+}
+
+.mini-player-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  margin-right: 10px;
+}
+
+.mini-player-controls {
+  display: flex;
+  gap: 4px;
+}
+
+.mini-control-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  padding: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  transition: all var(--transition-fast);
+}
+
+.mini-control-btn:hover {
+  background: rgba(0, 0, 0, 0.1);
+  color: var(--accent-color);
+  transform: scale(1.1);
+}
+
+.mini-control-btn .material-symbols-outlined {
+  font-size: 20px;
+}
+
+.mini-player-video {
+  width: 100%;
+  aspect-ratio: 16/9;
+  background: #000;
+}
+
+.mini-player-video iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+/* Mini Player Animations */
+@keyframes slideInUp {
+  from {
+    opacity: 0;
+    transform: translateY(100px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideOutDown {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(100px);
+  }
+}
+
+.mini-player.closing {
+  animation: slideOutDown 0.3s ease-out forwards;
+}
+
+/* Dark mode support for mini player */
+.dark-mode .mini-player {
+  background: #1a1a1a;
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.dark-mode .mini-player-header {
+  background: #0d0d0d;
+  border-bottom-color: rgba(255, 255, 255, 0.1);
+}
+
+.dark-mode .mini-control-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+/* Sepia mode support */
+.sepia-mode .mini-player {
+  background: #f5f0e8;
+  border-color: rgba(112, 66, 20, 0.2);
+}
+
+.sepia-mode .mini-player-header {
+  background: #f0e9dd;
+}
+
+/* High contrast mode support */
+.contrast-mode .mini-player {
+  background: #000;
+  border: 3px solid #fff;
+}
+
+.contrast-mode .mini-player-header {
+  background: #000;
+  border-bottom: 3px solid #fff;
+}
+
+.contrast-mode .mini-player-title {
+  color: #fff;
+}
+
+/* Responsive Mini Player */
+@media (max-width: 768px) {
+  .mini-player {
+    width: 320px;
+    bottom: 10px;
+    right: 10px;
+  }
+  
+  .pip-button {
+    padding: 6px;
+  }
+  
+  .pip-button .material-symbols-outlined {
+    font-size: 20px;
+  }
+}
+
+@media (max-width: 480px) {
+  .mini-player {
+    width: calc(100vw - 20px);
+    left: 10px;
+    right: 10px;
+  }
+}
+


### PR DESCRIPTION
## 📝 Description

Adds a **Picture-in-Picture (PiP) mini player** that lets users continue watching videos while browsing for other content, enhancing the multitasking experience.

## ✨ Features

- **Floating mini player** in bottom-right corner with drag-to-reposition
- **Seamless transitions** - clicking back button moves video to PiP without interrupting playback
- **Smart auto-close** - selecting a new video automatically closes PiP and plays in main player
- **Controls** - Maximize (⤢) and Close (✕) buttons for easy management
- **Keyboard shortcut** - Press `P` to toggle PiP mode
- **Theme support** - Works with all themes (light, dark, sepia, high contrast)

## 🔄 User Flow

1. Play video → Click back → Video moves to PiP (keeps playing)
2. Browse/search for new content while PiP plays in corner
3. Click new video → PiP auto-closes, new video plays in main player

## 🎯 Why This Feature?

Aligns with MeTube's mission of **"making content viewing easy and fast"**:
- ✅ Watch while searching for next video
- ✅ No playback interruption during navigation
- ✅ Faster content discovery
- ✅ YouTube-like familiar experience

## 🧪 Testing

- ✅ PiP activates on back, keeps playing
- ✅ New video selection auto-closes PiP
- ✅ Drag, maximize, close buttons work correctly
- ✅ Keyboard shortcut 'P' toggles PiP
- ✅ Compatible with all themes

## under Hacktoberfest-accepted
<img width="1847" height="883" alt="Screenshot 2025-10-22 190942" src="https://github.com/user-attachments/assets/6e63553d-480d-4fcc-b30d-400fb1826179" />

